### PR TITLE
Fixes for Python 3.x and Zope 6.x

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,7 @@ Running localmail
 
 .. code-block:: bash
 
-    twistd localmail
+    twistd -y localmail mail
 
 This will run localmail in the background, SMTP on port 2025 and IMAP on 2143,
 It will log to a file ./twistd.log. Use the -n option if you want to run in
@@ -45,14 +45,14 @@ the foreground, like so.
 
 .. code-block:: bash
 
-    twistd -n localmail
+    twistd -n -y localmail mail
 
 
 You can pass in arguments to control parameters.
 
 .. code-block:: bash
 
-   twistd localmail --imap <port> --smtp <port> --http <port> --file localmail.mbox
+   twistd  localmail --imap <port> --smtp <port> --http <port> --file localmail.mbox
 
 
 You can have localmail use random ports if you like. The port numbers will be logged.

--- a/localmail/cred.py
+++ b/localmail/cred.py
@@ -13,7 +13,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-from zope.interface import implements
+try:
+    # old
+    from zope.interface import implements
+except:
+    # 6.0+
+    from zope.interface import classImplements as implements
+    
 from twisted.internet import defer
 from twisted.cred import portal, checkers, credentials
 from twisted.mail import smtp, imap4

--- a/twisted/plugins/localmail_tap.py
+++ b/twisted/plugins/localmail_tap.py
@@ -13,7 +13,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program; if not, write to the Free Software
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
-from zope.interface import implements
+try:
+    from zope.interface import implements
+except:
+    # 6.0+
+    from zope.interface import classImplements as implements
 
 from twisted.application import service
 from twisted import plugin


### PR DESCRIPTION
Compatible fixes for Zope 6.x and Python 3.x